### PR TITLE
Adjust for variant

### DIFF
--- a/analysis/021_cruderates_timeupdated.R
+++ b/analysis/021_cruderates_timeupdated.R
@@ -34,6 +34,14 @@ calculate_timeupdated_rates <- function(data, grouping_var){
 
 # calculate crude rates ---------------------------------------------------
 time_updated_rates_all <- bind_rows(
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = sex),
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = age_cat),
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = practice_nuts),
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = imd_q5),
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = comorbidities),
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = highrisk_shield),
+  calculate_timeupdated_rates(time_data_lc_all, grouping_var = ethnicity),
+  calculate_timeupdated_rates(time_data_lc_all, variant),
   calculate_timeupdated_rates(time_data_lc_all, vaccines),
   calculate_timeupdated_rates(time_data_lc_all, t_vacc_mrna),
   calculate_timeupdated_rates(time_data_lc_all, t_vacc_primary)
@@ -42,6 +50,14 @@ time_updated_rates_all %>%
   write_csv(here("output/tab022_tuv_rates_lc_all.csv"))
 
 time_updated_rates_dx <- bind_rows(
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = sex),
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = age_cat),
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = practice_nuts),
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = imd_q5),
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = comorbidities),
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = highrisk_shield),
+  calculate_timeupdated_rates(time_data_lc_dx, grouping_var = ethnicity),
+  calculate_timeupdated_rates(time_data_lc_dx, variant),
   calculate_timeupdated_rates(time_data_lc_dx, vaccines),
   calculate_timeupdated_rates(time_data_lc_dx, t_vacc_mrna),
   calculate_timeupdated_rates(time_data_lc_dx, t_vacc_primary)

--- a/analysis/022_combine_cruderates.R
+++ b/analysis/022_combine_cruderates.R
@@ -9,10 +9,9 @@ output_dir_tab <- here("output/tables")
 fs::dir_create(output_dir_tab)
 fs::dir_create(here("output/figures"))
 
-redact_threshold = 7
+redact_threshold = 10
 
 # tidy crude rates .csv for review ----------------------------------------
-crude_rates_static <- read_csv(here("output/tab021_crude_lc_rates.csv"))
 crude_rates_tuv_lc_all <- read_csv(here("output/tab022_tuv_rates_lc_all.csv"))
 crude_rates_tuv_lc_dx <- read_csv(here("output/tab023_tuv_rates_lc_dx.csv"))
 
@@ -30,13 +29,9 @@ drop_vars <- c("n_fratures",
                "n_rx",
                "total_tests",
                "avg_last_vacc")
-crude_rates_static <- crude_rates_static %>%
-  dplyr::select(-all_of(drop_vars), -contains("errorfactor"), -contains("se_rate")) %>% 
-  filter(!str_detect(stratifier, "vacc"))
 
 #combine the two sets of results
-crude_rates <- crude_rates_static %>% 
-  bind_rows(crude_rates_tuv) %>% 
+crude_rates <- crude_rates_tuv %>% 
   mutate(fup = fup/1e5)
 
 tidy_crude_rates <- crude_rates %>% 
@@ -45,6 +40,7 @@ tidy_crude_rates <- crude_rates %>%
                       "sex",
                       "age_cat",
                       "practice_nuts",
+                      "variant",
                       "vaccines",
                       "t_vacc_primary",
                       "t_vacc_mrna",
@@ -57,6 +53,7 @@ tidy_crude_rates <- crude_rates %>%
                       "Age category",
                       "Sex",
                       "Region",
+                      "Dominant SARS-COV-2 variant",
                       "No. vaccine doses",
                       "First vaccine received",
                       "mRNA vaccine received",

--- a/analysis/041_poisson_regressions_timeupdated.R
+++ b/analysis/041_poisson_regressions_timeupdated.R
@@ -14,6 +14,13 @@ run_the_regressions <- function(data){
 
 stratifiers_t <-
   c(
+    "sex",
+    "age_cat",
+    "practice_nuts",
+    "ethnicity",
+    "imd_q5",
+    "comorbidities",
+    "highrisk_shield",
     "vaccines",
     "t_vacc_primary",
     "t_vacc_mrna"
@@ -21,6 +28,13 @@ stratifiers_t <-
 
 strat_plot_names_t <-
   c(
+    "Sex",
+    "Age category",
+    "Region",
+    "Ethnicity",
+    "IMD (quintile)",
+    "Comorbidities",
+    "Shielding (high risk group)",
     "No. vaccine doses",
     "First vaccine received",
     "mRNA vaccine received"

--- a/analysis/042_plot_poisson_results.R
+++ b/analysis/042_plot_poisson_results.R
@@ -8,10 +8,7 @@ library(here)
 source(here::here("analysis/functions/redaction.R"))
 source(here::here("analysis/functions/ggplot_theme.R"))
 
-adjusted_rates_out <- read_csv("output/tab023_poissonrates_timeupdated.csv") %>% 
-  bind_rows(
-    read_csv("output/tab023_poissonrates_static.csv")
-  )
+adjusted_rates_out <- read_csv("output/tab023_poissonrates_timeupdated.csv") 
 dir.create(here("output/figures"), showWarnings = FALSE, recursive=TRUE)
 dir.create(here("output/tables"), showWarnings = FALSE, recursive=TRUE)
 
@@ -127,7 +124,7 @@ create_forest_plot <- function(data_in, y_col_var, plot_rel_widths = c(7, 3), le
                         colour = get(y_col_var)
                       )) +
     geom_hline(yintercept = 1, colour = "gray60") +
-    geom_pointrange(size = 10, pch = 1, position = position_dodge(width = 0.5), width = 0.5) + 
+    geom_pointrange(size = 3, pch = 1, position = position_dodge(width = 0.5), width = 0.5) + 
     #geom_point(position = position_dodge(width = 0.5)) +
     labs(x = "", 
          y = "Rate ratio (95% Confidence Interval)",

--- a/project.yaml
+++ b/project.yaml
@@ -116,15 +116,6 @@ actions:
       moderately_sensitive: 
         daily_dynamics: output/data_daily_dynamics.csv
 
-  crude_rates:
-    run: >
-      r:latest
-        analysis/020_cruderates.R
-    needs: [clean_the_data]
-    outputs:
-      moderately_sensitive:
-        cruderates: output/tab021_crude_lc_rates.csv
-
   crude_rates_timeupdated:
     run: >
       r:latest
@@ -139,7 +130,7 @@ actions:
     run: >
       r:latest
         analysis/022_combine_cruderates.R
-    needs: [crude_rates, crude_rates_timeupdated]
+    needs: [crude_rates_timeupdated]
     outputs:
       moderately_sensitive:
         cruderates_redacted: output/tables/tab3_crude_rates_redacted.csv
@@ -189,15 +180,6 @@ actions:
         longcovid_flows: output/figures/fig5_longcovid_flows.pdf
         longcovid_flows_data: output/sankey_plot_data.csv
 
-  poisson_rates_static:
-    run: >
-      r:latest
-        analysis/040_poisson_regressions_staticvars.R
-    needs: [clean_the_data]
-    outputs:
-      moderately_sensitive:
-        poissonrates: output/tab023_poissonrates_static.csv
-
   poisson_rates_timeupdated:
     run: >
       r:latest
@@ -211,7 +193,7 @@ actions:
     run: >
       r:latest
         analysis/042_plot_poisson_results.R
-    needs: [poisson_rates_static, poisson_rates_timeupdated]
+    needs: [poisson_rates_timeupdated]
     outputs: 
       moderately_sensitive: 
         fig3a: output/figures/fig3a_crude_RRs.pdf


### PR DESCRIPTION
A major rewrite of the analysis to account for the fact that the dominant SARS-COV-2 variant was changing over the study period. 

All data are now time updated to reflect this and `variant` is included in the Poisson models estimating rates. This may be extended to stratify results by variant period.