### PR TITLE
Rename `is_between` ehrQL method

### DIFF
--- a/analysis/dataset_definition_longcovid_prevaccine.py
+++ b/analysis/dataset_definition_longcovid_prevaccine.py
@@ -115,16 +115,16 @@ dataset.define_population(population)
 # covid tests ------------------------------------------------------------
 dataset.first_test_post_lc = sgss_covid_all_tests \
     .where(sgss_covid_all_tests.is_positive) \
-    .where(sgss_covid_all_tests.specimen_taken_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+    .where(sgss_covid_all_tests.specimen_taken_date.is_between_but_not_on(dataset.pt_start_date, dataset.pt_end_date)) \
     .sort_by(sgss_covid_all_tests.specimen_taken_date).first_for_patient().specimen_taken_date
 
 dataset.all_test_positive = sgss_covid_all_tests \
     .where(sgss_covid_all_tests.is_positive) \
-    .where(sgss_covid_all_tests.specimen_taken_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+    .where(sgss_covid_all_tests.specimen_taken_date.is_between_but_not_on(dataset.pt_start_date, dataset.pt_end_date)) \
     .count_for_patient()
 
 dataset.all_tests = sgss_covid_all_tests \
-    .where(sgss_covid_all_tests.specimen_taken_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+    .where(sgss_covid_all_tests.specimen_taken_date.is_between_but_not_on(dataset.pt_start_date, dataset.pt_end_date)) \
     .count_for_patient()
 
 # VACCCINES ------------------------------------------------------------

--- a/analysis/datasets.py
+++ b/analysis/datasets.py
@@ -281,7 +281,7 @@ def add_common_variables(dataset, study_start_date, end_date, population):
     fracture_hospitalisations = hospitalisation_diagnosis_matches(hospital_admissions, codelists.hosp_fractures)
 
     dataset.first_fracture_hosp = fracture_hospitalisations \
-        .where(fracture_hospitalisations.admission_date.is_between(dataset.pt_start_date, dataset.pt_end_date)) \
+        .where(fracture_hospitalisations.admission_date.is_between_but_not_on(dataset.pt_start_date, dataset.pt_end_date)) \
         .sort_by(fracture_hospitalisations.admission_date) \
         .first_for_patient().admission_date
 

--- a/analysis/variable_lib.py
+++ b/analysis/variable_lib.py
@@ -138,6 +138,6 @@ def long_covid_dx_during(start, end):
 
 def long_covid_inhosp(start, end):
     in_study_admissions = schema.hospital_admissions \
-      .where(schema.hospital_admissions.admission_date.is_between(start, end))
+      .where(schema.hospital_admissions.admission_date.is_between_but_not_on(start, end))
 
     return hospitalisation_diagnosis_matches(admissions=in_study_admissions, codelist=codelists.long_covid_hosp)


### PR DESCRIPTION
This ehrQL method `is_between` has been renamed to `is_between_but_not_on`. The functionality of these two methods is identical.