### PR TITLE
Add sens analyses

### DIFF
--- a/analysis/015_timeupdate_data_sensAnalysis.R
+++ b/analysis/015_timeupdate_data_sensAnalysis.R
@@ -10,26 +10,54 @@ cleaned_data <- arrow::read_parquet(here::here("output/clean_dataset.gz.parquet"
 
 
 # sensitivity analysis - exclude recent vaccinations -------------------------
+
+
+# long covid - ALL --------------------------------------------------------
 ## exclude vaccine records that are within12 weeks of the end of f-up
 time_data_lc_all_sensAnalysis <- time_update_vaccinedoses(cleaned_data, first_lc, exclude_recent_vacc = TRUE, exclusion_window = 12*7)
+
+## save the file
 arrow::write_parquet(time_data_lc_all_sensAnalysis, 
-                     sink = here::here("output/timeupdate_dataset_lc_all_sensAnalysis.gz.parquet"),
+                     sink = here::here("output/timeupdate_dataset_lc_all_sensAnalysis_12wks.gz.parquet"),
                      compression = "gzip", compression_level = 5)
+
 # delete the big dataset to save memory 
 time_data_lc_all_sensAnalysis <- NULL
 
-# Long COVID Dx only
-time_data_lc_dx_sensAnalysis <- time_update_vaccinedoses(cleaned_data, first_lc_dx, exclude_recent_vacc = TRUE, exclusion_window = 12*7)
-arrow::write_parquet(time_data_lc_dx_sensAnalysis, 
-                     sink = here::here("output/timeupdate_dataset_lc_dx_sensAnalysis.gz.parquet"),
+
+## repeat for 4 weeks
+time_data_lc_all_sensAnalysis <- time_update_vaccinedoses(cleaned_data, first_lc, exclude_recent_vacc = TRUE, exclusion_window = 4*7)
+arrow::write_parquet(time_data_lc_all_sensAnalysis, 
+                     sink = here::here("output/timeupdate_dataset_lc_all_sensAnalysis_4wks.gz.parquet"),
                      compression = "gzip", compression_level = 5)
+time_data_lc_all_sensAnalysis <- NULL
+
+# Long COVID Dx only --------------------------------------------------------
+
+## 12 weeks
+time_data_lc_dx_sensAnalysis <- time_update_vaccinedoses(cleaned_data, first_lc_dx, exclude_recent_vacc = TRUE, exclusion_window = 12*7)
+
+## save file 
+arrow::write_parquet(time_data_lc_dx_sensAnalysis, 
+                     sink = here::here("output/timeupdate_dataset_lc_dx_sensAnalysis_12wks.gz.parquet"),
+                     compression = "gzip", compression_level = 5)
+
 # delete the big dataset to save memory 
 time_data_lc_dx_sensAnalysis <- NULL
 
-# hospitalised with COVID-19 - exclude <= 2 weeks before event
+## repeat for 4 weeks
+time_data_lc_dx_sensAnalysis <- time_update_vaccinedoses(cleaned_data, first_lc_dx, exclude_recent_vacc = TRUE, exclusion_window = 4*7)
+arrow::write_parquet(time_data_lc_dx_sensAnalysis, 
+                     sink = here::here("output/timeupdate_dataset_lc_dx_sensAnalysis_4wks.gz.parquet"),
+                     compression = "gzip", compression_level = 5)
+
+time_data_lc_dx_sensAnalysis <- NULL
+
+# COVID hospitalisations --------------------------------------------------
+# hospitalised with COVID-19 - exclude <= 2 weeks before event ONLY
 time_data_covidhosp_sensAnalysis <- time_update_vaccinedoses(cleaned_data, first_covid_hosp, exclude_recent_vacc = TRUE, exclusion_window = 2*7)
 arrow::write_parquet(time_data_covidhosp_sensAnalysis, 
-                     sink = here::here("output/timeupdate_dataset_covidhosp_sensAnalysis.gz.parquet"),
+                     sink = here::here("output/timeupdate_dataset_covidhosp_sensAnalysis_2wks.gz.parquet"),
                      compression = "gzip", compression_level = 5)
 # delete the big dataset to save memory 
 time_data_covidhosp_sensAnalysis <- NULL

--- a/analysis/021_cruderates_timeupdated.R
+++ b/analysis/021_cruderates_timeupdated.R
@@ -43,8 +43,7 @@ time_updated_rates_all <- bind_rows(
   calculate_timeupdated_rates(time_data_lc_all, grouping_var = ethnicity),
   calculate_timeupdated_rates(time_data_lc_all, variant),
   calculate_timeupdated_rates(time_data_lc_all, vaccines),
-  calculate_timeupdated_rates(time_data_lc_all, t_vacc_mrna),
-  calculate_timeupdated_rates(time_data_lc_all, t_vacc_primary)
+  calculate_timeupdated_rates(time_data_lc_all, t_vacc_mrna)
 )
 time_updated_rates_all %>% 
   write_csv(here("output/tab022_tuv_rates_lc_all.csv"))
@@ -59,8 +58,7 @@ time_updated_rates_dx <- bind_rows(
   calculate_timeupdated_rates(time_data_lc_dx, grouping_var = ethnicity),
   calculate_timeupdated_rates(time_data_lc_dx, variant),
   calculate_timeupdated_rates(time_data_lc_dx, vaccines),
-  calculate_timeupdated_rates(time_data_lc_dx, t_vacc_mrna),
-  calculate_timeupdated_rates(time_data_lc_dx, t_vacc_primary)
+  calculate_timeupdated_rates(time_data_lc_dx, t_vacc_mrna)
 )
 time_updated_rates_dx %>% 
   write_csv(here("output/tab023_tuv_rates_lc_dx.csv"))

--- a/analysis/040_poisson_checks.R
+++ b/analysis/040_poisson_checks.R
@@ -4,7 +4,6 @@ library(lubridate)
 library(here)
 
 source(here::here("analysis/functions/redaction.R"))
-source(here::here("analysis/functions/poisson_regressions.R"))
 
 dir.create(here::here("output/data_properties/poisson_checks/"), showWarnings = FALSE, recursive=TRUE)
 

--- a/analysis/043_poisson_regressions_timeupdated_sensAnalysis.R
+++ b/analysis/043_poisson_regressions_timeupdated_sensAnalysis.R
@@ -37,52 +37,73 @@ vars_for_regressions <- c("patient_id",
                           "t_vacc_mrna", 
                           "variant",
                           "out")
-# import data ------------------------------------------------------------
-## import clean_Data to get the region data
+
+
+# import data -------------------------------------------------------------
+## import clean_data to get the region data
 clean_data <- arrow::read_parquet(here::here("output/clean_dataset.gz.parquet")) %>% 
   dplyr::select(patient_id, region = practice_nuts, comorbid = comorbidities, imd = imd_q5)
 
+# ALL long covid as an outcome --------------------------------------------
 ## 1 - import All Long COVID codes as outcome - merge on region
-time_data_lc_all_sensAnalysis <- arrow::read_parquet(here::here("output/timeupdate_dataset_lc_all_sensAnalysis.gz.parquet")) %>%
+time_data_lc_all_sensAnalysis_12wks <- arrow::read_parquet(here::here("output/timeupdate_dataset_lc_all_sensAnalysis_12wks.gz.parquet")) %>%
   dplyr::select(all_of(vars_for_regressions)) %>% 
   left_join(clean_data, by = "patient_id")
 
 ## run the regressions
-adjusted_rates_t_lc_all <- run_the_regressions_collapsed(data = time_data_lc_all_sensAnalysis)
+adjusted_rates_t_lc_all_12wks <- run_the_regressions_collapsed(data = time_data_lc_all_sensAnalysis_12wks)
+## got to add on a new column to denote which sensAnalysis is being regressed
+adjusted_rates_t_lc_all_12wks <- lapply(adjusted_rates_t_lc_all_12wks, function(x){bind_cols(x, sa = "12 weeks")})
 
 ## remove the big time-data frame to save memory
-time_data_lc_all_sensAnalysis <- NULL
+time_data_lc_all_sensAnalysis_12wks <- NULL
 
-## 2 - import Long COVID Dx codes only as outcome - merge on region
-time_data_lc_dx_sensAnalysis <- arrow::read_parquet(here::here("output/timeupdate_dataset_lc_dx_sensAnalysis.gz.parquet")) %>%
+## repeat for 4 weeks
+time_data_lc_all_sensAnalysis_4wks <- arrow::read_parquet(here::here("output/timeupdate_dataset_lc_all_sensAnalysis_4wks.gz.parquet")) %>%
   dplyr::select(all_of(vars_for_regressions)) %>% 
   left_join(clean_data, by = "patient_id")
+adjusted_rates_t_lc_all_4wks <- run_the_regressions_collapsed(data = time_data_lc_all_sensAnalysis_4wks)
+adjusted_rates_t_lc_all_4wks <- lapply(adjusted_rates_t_lc_all_4wks, function(x){bind_cols(x, sa = "4 weeks")})
+time_data_lc_all_sensAnalysis_4wks <- NULL
 
-## run the regressions
-adjusted_rates_t_lc_dx <- run_the_regressions_collapsed(data = time_data_lc_dx_sensAnalysis)
 
-## remove the big time-data frame to save memory
-time_data_lc_dx_sensAnalysis <- NULL
-
-## 3 - Hospitalised with COVID-19 as outcome - merge on region
-time_data_covidhosp_sensAnalysis <- arrow::read_parquet(here::here("output/timeupdate_dataset_covidhosp_sensAnalysis.gz.parquet")) %>%
+# Long COVID Diagnoses only -----------------------------------------------
+## 12 week exclusion window
+time_data_lc_dx_sensAnalysis_12wks <- arrow::read_parquet(here::here("output/timeupdate_dataset_lc_dx_sensAnalysis_12wks.gz.parquet")) %>%
   dplyr::select(all_of(vars_for_regressions)) %>% 
   left_join(clean_data, by = "patient_id")
+adjusted_rates_t_lc_dx_12wks <- run_the_regressions_collapsed(data = time_data_lc_dx_sensAnalysis_12wks)
+adjusted_rates_t_lc_dx_12wks <- lapply(adjusted_rates_t_lc_dx_12wks, function(x){bind_cols(x, sa = "12 weeks")})
+time_data_lc_dx_sensAnalysis_12wks <- NULL
 
-## run the regressions
-adjusted_rates_t_covidhosp <- run_the_regressions_collapsed(data = time_data_covidhosp_sensAnalysis)
+## 4 week exclusion window
+time_data_lc_dx_sensAnalysis_4wks <- arrow::read_parquet(here::here("output/timeupdate_dataset_lc_dx_sensAnalysis_4wks.gz.parquet")) %>%
+  dplyr::select(all_of(vars_for_regressions)) %>% 
+  left_join(clean_data, by = "patient_id")
+adjusted_rates_t_lc_dx_4wks <- run_the_regressions_collapsed(data = time_data_lc_dx_sensAnalysis_4wks)
+adjusted_rates_t_lc_dx_4wks <- lapply(adjusted_rates_t_lc_dx_4wks, function(x){bind_cols(x, sa = "4 weeks")})
+time_data_lc_dx_sensAnalysis_4wks <- NULL
 
-## remove the big time-data frame to save memory
-time_data_covidhosp_sensAnalysis <- NULL
-
+# covid-hospitalisation ---------------------------------------------------
+## 3 - Hospitalised with COVID-19 as outcome - 2wks exclusion window only
+time_data_covidhosp_sensAnalysis_2wks <- arrow::read_parquet(here::here("output/timeupdate_dataset_covidhosp_sensAnalysis_2wks.gz.parquet")) %>%
+  dplyr::select(all_of(vars_for_regressions)) %>% 
+  left_join(clean_data, by = "patient_id")
+adjusted_rates_t_covidhosp_2wks <- run_the_regressions_collapsed(data = time_data_covidhosp_sensAnalysis_2wks)
+adjusted_rates_t_covidhosp_2wks <- lapply(adjusted_rates_t_covidhosp_2wks, function(x){bind_cols(x, sa = "2 weeks")})
+time_data_covidhosp_sensAnalysis_2wks <- NULL
 
 # group the outcomes ------------------------------------------------------
 adjusted_rates_out <- NULL
-adjusted_rates_list <- c("adjusted_rates_t_lc_all",
-                         "adjusted_rates_t_lc_dx",
-                         "adjusted_rates_t_covidhosp")
-outcome_list <- c("All Long COVID", 
+adjusted_rates_list <- c("adjusted_rates_t_lc_all_12wks",
+                         "adjusted_rates_t_lc_all_4wks",
+                         "adjusted_rates_t_lc_dx_12wks",
+                         "adjusted_rates_t_lc_dx_4wks",
+                         "adjusted_rates_t_covidhosp_2wks")
+outcome_list <- c("All Long COVID",
+                  "All Long COVID",
                   "Long COVID diagnoses", 
+                  "Long COVID diagnoses",
                   "COVID-19 hospitalisation")
 for(j in 1:length(adjusted_rates_list)){
   adjusted_rates_temp <- bind_rows(get(adjusted_rates_list[j]))

--- a/project.yaml
+++ b/project.yaml
@@ -259,9 +259,11 @@ actions:
     needs: [clean_the_data]
     outputs: 
       highly_sensitive: 
-        timedata_longcovid_sensAnalysis: output/timeupdate_dataset_lc_all_sensAnalysis.gz.parquet
-        timedata_longcovid_dx_sensAnalysis: output/timeupdate_dataset_lc_dx_sensAnalysis.gz.parquet
-        timedata_covid_hosp_sensAnalysis: output/timeupdate_dataset_covidhosp_sensAnalysis.gz.parquet
+        timedata_longcovid_sensAnalysis_12wks: output/timeupdate_dataset_lc_all_sensAnalysis_12wks.gz.parquet
+        timedata_longcovid_sensAnalysis_4wks: output/timeupdate_dataset_lc_all_sensAnalysis_4wks.gz.parquet
+        timedata_longcovid_dx_sensAnalysis_12wks: output/timeupdate_dataset_lc_dx_sensAnalysis_12wks.gz.parquet
+        timedata_longcovid_dx_sensAnalysis_4wks: output/timeupdate_dataset_lc_dx_sensAnalysis_4wks.gz.parquet
+        timedata_covid_hosp_sensAnalysis_2wks: output/timeupdate_dataset_covidhosp_sensAnalysis_2wks.gz.parquet
   
   poisson_rates_timeupdated_sensAnalysis:
     run: >


### PR DESCRIPTION
Separated out the sensitivity analysis process into two separate sets of file: 
1. exclude vaccine records ≤4 weeks before the end of follow-up
2. exclude vaccine records ≤12 weeks before the end of follow-up

Also fixed a bug in the time-updating code where the mRNA vaccine dates were not being updated with the exclusion window