### PR TITLE
Update `ons_deaths` table

### DIFF
--- a/analysis/dataset_definition_longcovid_prevaccine.py
+++ b/analysis/dataset_definition_longcovid_prevaccine.py
@@ -97,9 +97,7 @@ dataset.imd = address_as_of(study_start_date).imd_rounded
 
 # death ------------------------------------------------------------
 dataset.death_date = patients.date_of_death
-ons_deathdata = ons_deaths \
-    .sort_by(ons_deaths.date).last_for_patient()
-dataset.ons_death_date = ons_deathdata.date
+dataset.ons_death_date = ons_deaths.date
 
 # Ethnicity in 6 categories ------------------------------------------------------------
 dataset.ethnicity = clinical_events.where(clinical_events.ctv3_code.is_in(codelists.ethnicity)) \

--- a/analysis/datasets.py
+++ b/analysis/datasets.py
@@ -65,9 +65,7 @@ def add_common_variables(dataset, study_start_date, end_date, population):
 
     # death ------------------------------------------------------------
     dataset.death_date = patients.date_of_death
-    ons_deathdata = ons_deaths \
-        .sort_by(ons_deaths.date).last_for_patient()
-    dataset.ons_death_date = ons_deathdata.date
+    dataset.ons_death_date = ons_deaths.date
 
     # Ethnicity in 6 categories ------------------------------------------------------------
     dataset.ethnicity = clinical_events.where(clinical_events.ctv3_code.is_in(codelists.ethnicity)) \


### PR DESCRIPTION
The `ons_deaths` table is now a PatientFrame (with one row per patient) so it is no longer needed to select one event per patient from the ons_deaths table.